### PR TITLE
account for colon in labels of interaction effects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mitml
 Type: Package
 Title: Tools for Multiple Imputation in Multilevel Modeling
-Version: 0.3-5.7
+Version: 0.3-5.8
 Date: 2018-02-08
 Author:  Simon Grund [aut,cre], Alexander Robitzsch [aut], Oliver Luedtke [aut]
 Maintainer: Simon Grund <grund@ipn.uni-kiel.de>

--- a/R/testConstraints.R
+++ b/R/testConstraints.R
@@ -10,7 +10,8 @@ testConstraints <- function(model, qhat, uhat, constraints, method=c("D1","D2"),
   method <- match.arg(method)
 
   cons <- gsub("\\(Intercept\\)","Intercept",constraints)
-
+  cons <- gsub(":","_.x._", cons)
+  
   # warnings for ignored arguments
   if(!is.null(df.com) & method=="D2") warning("Setting complete-data degrees of freedom is only available for 'D1' and will be ignored with 'D2'.")
 
@@ -100,6 +101,7 @@ testConstraints <- function(model, qhat, uhat, constraints, method=c("D1","D2"),
     theta <- Qhat[,ii]
     Sigma <- Uhat[,,ii]
     names(theta) <- gsub("\\(Intercept\\)","Intercept",names(theta))
+    names(theta) <- gsub(":","_.x._",names(theta))
 
     g <- parse(text=cons)
     env.g <- new.env()
@@ -169,6 +171,9 @@ testConstraints <- function(model, qhat, uhat, constraints, method=c("D1","D2"),
   out <- matrix(c(val,k,v,p,r),ncol=5)
   colnames(out) <- c("F.value","df1","df2","P(>F)","RIV")   # new label for p-value, SiG 2017-02-09
 
+  ## return interaction labels to their original form (":")
+  cons <- gsub("_.x._",":", cons)
+  
   out <- list(
     call=match.call(),
     constraints=cons,


### PR DESCRIPTION
Hello Simon (and Alexander and Oliver),

I met you all at IMPS in Switzerland last summer, and enjoyed speaking to you all about missing-data topics.  I really appreciate this package, as I was previously writing my own routines for consultation.  

I noticed that specifying slopes for interaction terms in `testConstraints()` returned an error, and I see that the problem is that the values of slopes are assigned to objects with the names of their effects by evaluating them in a new environment.  As a quick fix, I added another instance of `gsub` below your replacement of `(Intercept)` with `Intercept`, which replaces the colon (`:`) with `_.x._` to indicate product terms.  The colon was producing a range between two different slopes when evaluated (e.g., `x:y` would be evaluated as the slope of `x` through the slope of `y` rather than the `x:y` slope).  I doubt any effects would ever be named with `_.x._`, so this should not cause problems.  It also return it back to the familiar colon so that the label is preserved in the `print()` output.  Adapting your help-page example:
```
data(studentratings)
fml <- MathDis + ReadDis + SchClimate ~ (1|ID)
imp <- panImpute(studentratings, formula=fml, n.burn=1000, n.iter=100, m=5)
implist <- mitmlComplete(imp, print=1:5)
# fit regression model with moderating effect of sex
fit.lm <- with(implist, lm(SchClimate ~ Sex*(ReadDis + MathDis)))
testEstimates(fit.lm)
# test null hypothesis of no interaction
cons <- c("SexGirl:ReadDis","SexGirl:MathDis")
testConstraints(fit.lm, constraints=cons)
```

I will utilize this package in an upcoming missing-data workshop at the APS conference in San Fransisco (May 27, 2018).  **Would it be possible to upload this version to CRAN before then?**  If not, I can show them how to install my version from GitHub using `devtools::install_github()`.

Thank you!
Terrence