### PR TITLE
Fix weaving with knitr version 1.36

### DIFF
--- a/vignettes/Analysis.Rmd
+++ b/vignettes/Analysis.Rmd
@@ -90,13 +90,13 @@ This method can be used to apply arbitrary transformations to all of the complet
 > Due to how it is implemented, `within` cannot be used directly with `dplyr`.
 > Instead, users may use `with` instead of `within` with the following workaround.
 >```{r, eval=FALSE}
-implist <- with(implist,{
-   df <- data.frame(as.list(environment()))
-   df <- ... # dplyr commands
-   df
-})
-implist <- as.mitml.list(implist)
-```
+>implist <- with(implist,{
+>   df <- data.frame(as.list(environment()))
+>   df <- ... # dplyr commands
+>   df
+>})
+>implist <- as.mitml.list(implist)
+>```
 > Advanced users may also consider using `lapply` for a similar workaround.<span style="color:white">`</span>
 
 ## Fitting the analysis model


### PR DESCRIPTION
Hi,

with knitr version 1.36 (current CRAN-latest) the weaving for Analysis.Rmd fails with:

```
$ R CMD Sweave vignettes/Analysis.Rmd 
*** This is beta software. Please report any bugs!
*** See the NEWS file for recent changes.
Loading required package: Matrix
Quitting from lines 109-125 (Analysis.Rmd) 
Error in parse(text = x, srcfile = src) : 
  attempt to use zero-length variable name
Calls: <Anonymous> ... <Anonymous> -> parse_all -> parse_all.character -> parse
Execution halted
```
This is an attempt to fix the same. It is also possible to fix it with simply pre-fixing the just last ` ``` ` with a `>` too, but that looks inconsistent and ugly.